### PR TITLE
Issues with key sequences

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./happydom.ts"

--- a/happydom.ts
+++ b/happydom.ts
@@ -1,0 +1,2 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+GlobalRegistrator.register();

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "compile:watch": "tsex compile --watch",
     "demo": "vite demo",
     "test": "tsex test",
+    "bun:test": "bun test",
     "test:watch": "tsex test --watch",
     "prepublishOnly": "tsex prepare"
   },
@@ -23,7 +24,11 @@
     "library"
   ],
   "devDependencies": {
+    "@happy-dom/global-registrator": "^12.9.1",
+    "bun": "^1.0.5",
+    "bun-types": "^1.0.5-canary.20231009T140142",
     "fava": "^0.2.1",
+    "happy-dom": "^12.9.1",
     "tsex": "^3.0.1",
     "typescript": "^5.1.6",
     "vite": "^4.4.9"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,68 @@
+/// <reference lib="dom" />
+
+import {test, expect} from 'bun:test';
+import ShoSho from '../dist/index.js';
+
+const keys = {
+  f: {'key': 'f'},
+  g: {'key': 'g'},
+  h: {'key': 'h'},
+}
+
+function keypress(key){
+  document.dispatchEvent(new KeyboardEvent('keydown', keys[key]));
+  document.dispatchEvent(new KeyboardEvent('keyup', keys[key]));
+}
+
+test ( 'key sequences do not trigger single key shortcuts', async () => {
+  let f_pressed = 0;
+  let g_pressed = 0;
+  let fg_pressed = 0;
+
+  const sho = new ShoSho ();
+  sho.register('f', () => { f_pressed++; });
+  sho.register('g', () => { g_pressed++; });
+  sho.register('f g', () => { fg_pressed++; return true });
+  sho.start()
+
+  keypress('f')
+  expect(f_pressed).toEqual(1)
+
+  await new Promise(resolve => setTimeout(() => resolve(''), 1000));
+
+  keypress('g')
+  expect(g_pressed).toEqual(1)
+  expect(fg_pressed).toEqual(0)
+
+  keypress('f')
+  keypress('g')
+  expect(f_pressed).toEqual(1)
+  expect(g_pressed).toEqual(1)
+  expect(fg_pressed).toEqual(1)
+})
+
+test ( 'key sequences are not triggered by single keys', () => {
+  let fg_pressed = 0;
+  let fh_pressed = 0;
+
+  const sho = new ShoSho ();
+
+  sho.register('f g', () => { fg_pressed++; return true });
+  sho.register('f h', () => { fh_pressed++; return true });
+  sho.start()
+
+  keypress('f')
+  keypress('g')
+  expect(fg_pressed).toEqual(1)
+  expect(fh_pressed).toEqual(0)
+
+  keypress('f')
+  keypress('h')
+  expect(fg_pressed).toEqual(1)
+  expect(fh_pressed).toEqual(1)
+
+  keypress('g')
+  keypress('h')
+  expect(fg_pressed).toEqual(1)
+  expect(fh_pressed).toEqual(1)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "tsex/tsconfig.json",
   "compilerOptions": {
+    "lib": ["esnext", "dom"],
     "noImplicitAny": false
   }
 }


### PR DESCRIPTION
I think I stumbled upon two issues in ShoSho that I couldn't get resolved. There might be an issue in ShoSho, or I might use it wrong.

1. I think it should be possible to add both single key shortcuts, as well as key sequence shortcuts that contain the same keys; however, I couldn't get this to work
2. ShoSho seems to trigger sequences again, even if only the last key is pressed (without the sequence before)

I couldn't get ShoSho to run with fava, so I added some very basic bun/happydom tests to illustrate these issues.